### PR TITLE
Update gitignore

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -7,6 +7,8 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
+package-lock.json
+
 node_modules
 dist
 dist-ssr


### PR DESCRIPTION
El gitignore del cliente no posee al package-lock y puede llegar a subirse por algún descuido. 